### PR TITLE
pdf2write.sh Quality of Life Improvements

### DIFF
--- a/pdf2write.sh
+++ b/pdf2write.sh
@@ -52,38 +52,38 @@ PDFSIN=()
 # https://stackoverflow.com/questions/192249/how-do-i-parse-command-line-arguments-in-bash
 while [[ $# -gt 0 ]]
 do
-key="$1"
+  key="$1"
 
-case $key in
-  -f|--fg|--foreground)
-  FOREGROUND=true
-  shift # past argument
-  ;;
-  --nozip)
-  COMPRESS=false
-  shift # past argument
-  ;;
-  #-d|--dpi)
-  #DPI="$2"
-  #shift # past argument
-  #shift # past value
-  #;;
-  *)    # unknown option
-  shift # past argument
-  if [ -z "$key" ] # verify argument isn't empty
-  then
-    continue
-  fi
+  case $key in
+    -f|--fg|--foreground)
+      FOREGROUND=true
+      shift # past argument
+      ;;
+    --nozip)
+      COMPRESS=false
+      shift # past argument
+      ;;
+    #-d|--dpi)
+      #DPI="$2"
+      #shift # past argument
+      #shift # past value
+      #;;
+    *)    # unknown option
+      shift # past argument
+      if [ -z "$key" ] # verify argument isn't empty
+      then
+        continue
+      fi
 
-  if ! [[ $key =~ \.pdf$ ]]; # verify argument is a pdf
-  then
-    echo "Ignoring $key as it is not a PDF file"
-    continue
-  fi
+      if ! [[ $key =~ \.pdf$ ]]; # verify argument is a pdf
+      then
+        echo "Ignoring $key as it is not a PDF file"
+        continue
+      fi
 
-  PDFSIN+="$key"
-  ;;
-esac
+      PDFSIN+="$key"
+      ;;
+  esac
 done
 
 if [ ${#PDFSIN[@]} -eq 0 ]

--- a/pdf2write.sh
+++ b/pdf2write.sh
@@ -81,7 +81,7 @@ do
         continue
       fi
 
-      PDFSIN+="$key"
+      PDFSIN+=("$key")
       ;;
   esac
 done
@@ -95,7 +95,7 @@ then
   exit 1
 fi
 
-for PDF in "$PDFSIN"
+for PDF in "${PDFSIN[@]}"
 do
   echo "Converting $PDF to images..."
   pdf2images "$PDF"

--- a/pdf2write.sh
+++ b/pdf2write.sh
@@ -48,7 +48,7 @@ images2write() {
 
 FOREGROUND=false
 COMPRESS=true
-PDFIN=''
+PDFSIN=()
 # https://stackoverflow.com/questions/192249/how-do-i-parse-command-line-arguments-in-bash
 while [[ $# -gt 0 ]]
 do
@@ -69,13 +69,24 @@ case $key in
   #shift # past value
   #;;
   *)    # unknown option
-  PDFIN="$1"
   shift # past argument
+  if [ -z "$key" ] # verify argument isn't empty
+  then
+    continue
+  fi
+
+  if ! [[ $key =~ \.pdf$ ]]; # verify argument is a pdf
+  then
+    echo "Ignoring $key as it is not a PDF file"
+    continue
+  fi
+
+  PDFSIN+="$key"
   ;;
 esac
 done
 
-if [ -z "$PDFIN" ]
+if [ ${#PDFSIN[@]} -eq 0 ]
 then
   echo "pdf2write.sh: Convert PDF to svg document for Stylus Labs Write"
   echo "Usage: pdf2write.sh [options] [PDF-file]"
@@ -84,20 +95,8 @@ then
   exit 1
 fi
 
-for PDF in "$PDFIN"
+for PDF in "$PDFSIN"
 do
-  # verify argument isn't empty
-  if [ -z "$PDF" ]
-  then
-    continue
-  fi
-
-  if ! [[ $PDF =~ \.pdf$ ]];
-  then
-    echo "Skipping $PDF as it is not a PDF file"
-    continue
-  fi
-
   echo "Converting $PDF to images..."
   pdf2images "$PDF"
 

--- a/pdf2write.sh
+++ b/pdf2write.sh
@@ -105,8 +105,8 @@ done
 
 if [ ${#PDFSIN[@]} -eq 0 ]
 then
-  echo "pdf2write.sh: Convert PDF to svg document for Stylus Labs Write"
-  echo "Usage: pdf2write.sh [options] [PDF-file]"
+  echo "pdf2write.sh: Convert PDF(s) to svg document(s) for Stylus Labs Write"
+  echo "Usage: pdf2write.sh [options] [PDF-files]"
   echo "  -f,--fg,--foreground: place page images in editable layer instead of ruling layer"
   echo "  --nozip: generate uncompressed svg instead of svgz"
   exit 1

--- a/pdf2write.sh
+++ b/pdf2write.sh
@@ -1,43 +1,57 @@
 #!/bin/bash
 # Create a Write document from a PDF by generating page images
 
+pdf2images() {
+  (command -v pdftoppm >/dev/null 2>&1 && pdftoppm -png -r 300 $1 out) || convert -density 300 -scene 1 $1 out-%03d.png
+  if [ ! -f "out-1.png" ] && [ ! -f "out-01.png" ] && [ ! -f "out-001.png" ]; then
+    echo "No page images found: make sure pdftoppm (from poppler-utils) or imagemagick and ghostscript are installed"
+    exit 1
+  fi
+}
+
+images2write() {
+  printf '<svg id="write-document" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">\n' > $1
+  printf '<rect id="write-doc-background" width="100%%" height="100%%" fill="#808080"/>\n' >> $1
+
+  local pngpage
+  for pngpage in out-*.png
+  do
+    local width2
+    local height2
+    read width2 height2 < <(file $pngpage | cut -d "," -f 2 | cut -d " " -f 2,4)
+    # page images generated at 300 DPI but Write uses 150 DPI as reference
+    local width=$((width2/2))
+    local height=$((height2/2))
+
+    printf '<svg class="write-page" color-interpolation="linearRGB" x="10" y="10" width="%dpx" height="%dpx" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">\n' $width $height >> $1
+    printf '  <g class="write-content write-v3" xruling="0" yruling="40" marginLeft="100" papercolor="#FFFFFF" rulecolor="#9F0000FF">\n' >> $1
+    printf '    <g class="ruleline write-no-dup" shape-rendering="crispEdges">\n' >> $1
+    printf '      <rect class="pagerect" fill="#FFFFFF" stroke="none" x="0" y="0" width="%d" height="%d" />\n' $width $height >> $1
+
+    printf '      <image x="0" y="0" width="%d" height="%d" xlink:href="data:image/png;base64,' $width $height >> $1
+    # doesn't seem to be a way to prevent base64 from appending newline
+    base64 $pngpage | tr -d '\n' >> $1
+    printf '"/>\n    </g>\n  </g>\n</svg>' >> $1
+  done
+
+  printf "\n</svg>" >> $1
+
+  gzip -S z $1
+  rm out-*.png
+}
+
+
+# Main
+
 if [ $# -eq 0 ]; then
   echo "No arguments provided. Please specify a PDF to convert with 'pdf2write.sh /path/to/foo.pdf'"
   exit 0
 fi
 
 echo "Converting PDF to images..."
-(command -v pdftoppm >/dev/null 2>&1 && pdftoppm -png -r 300 $1 out) || convert -density 300 -scene 1 $1 out-%03d.png
-if [ ! -f "out-1.png" ] && [ ! -f "out-01.png" ] && [ ! -f "out-001.png" ]; then
-  echo "No page images found: make sure pdftoppm (from poppler-utils) or imagemagick and ghostscript are installed"
-  exit 1
-fi
-SVGOUT=$(basename $1 pdf)svg
+pdf2images $1
+
 echo "Generating Write document..."
-
-printf '<svg id="write-document" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">\n' > $SVGOUT
-printf '<rect id="write-doc-background" width="100%%" height="100%%" fill="#808080"/>\n' >> $SVGOUT
-
-for PNGPAGE in out-*.png
-do
-  read WIDTH2 HEIGHT2 < <(file $PNGPAGE | cut -d "," -f 2 | cut -d " " -f 2,4)
-  # page images generated at 300 DPI but Write uses 150 DPI as reference
-  WIDTH=$((WIDTH2/2))
-  HEIGHT=$((HEIGHT2/2))
-
-  printf '<svg class="write-page" color-interpolation="linearRGB" x="10" y="10" width="%dpx" height="%dpx" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">\n' $WIDTH $HEIGHT >> $SVGOUT
-  printf '  <g class="write-content write-v3" xruling="0" yruling="40" marginLeft="100" papercolor="#FFFFFF" rulecolor="#9F0000FF">\n' >> $SVGOUT
-  printf '    <g class="ruleline write-no-dup" shape-rendering="crispEdges">\n' >> $SVGOUT
-  printf '      <rect class="pagerect" fill="#FFFFFF" stroke="none" x="0" y="0" width="%d" height="%d" />\n' $WIDTH $HEIGHT >> $SVGOUT
-
-  printf '      <image x="0" y="0" width="%d" height="%d" xlink:href="data:image/png;base64,' $WIDTH $HEIGHT >> $SVGOUT
-  # doesn't seem to be a way to prevent base64 from appending newline
-  base64 $PNGPAGE | tr -d '\n' >> $SVGOUT
-  printf '"/>\n    </g>\n  </g>\n</svg>' >> $SVGOUT
-done
-
-printf "\n</svg>" >> $SVGOUT
-
-gzip -S z $SVGOUT
-rm out-*.png
-echo "Finished creating $SVGOUT"z
+SVGOUT=$(basename $1 pdf)svg
+images2write $SVGOUT
+echo "Finished creating ${SVGOUT}z"

--- a/pdf2write.sh
+++ b/pdf2write.sh
@@ -89,6 +89,10 @@ do
       #shift # past argument
       #shift # past value
       #;;
+    -*|--*)
+      echo "Invalid option '$key', ignoring"
+      shift # past argument
+      ;;
     *)    # unknown option
       shift # past argument
       if verifyPdf "$key"

--- a/pdf2write.sh
+++ b/pdf2write.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 # Create a Write document from a PDF by generating page images
 
+if [ $# -eq 0 ]; then
+    echo "No arguments provided. Please specify a PDF to convert with 'pdf2write.sh /path/to/foo.pdf'"
+    exit 0
+fi
+
 echo "Converting PDF to images..."
 (command -v pdftoppm >/dev/null 2>&1 && pdftoppm -png -r 300 $1 out) || convert -density 300 -scene 1 $1 out-%03d.png
 if [ ! -f "out-1.png" ] && [ ! -f "out-01.png" ] && [ ! -f "out-001.png" ]; then

--- a/pdf2write.sh
+++ b/pdf2write.sh
@@ -2,7 +2,7 @@
 # Create a Write document from a PDF by generating page images
 
 pdf2images() {
-  (command -v pdftoppm >/dev/null 2>&1 && pdftoppm -png -r 300 $1 out) || convert -density 300 -scene 1 $1 out-%03d.png
+  (command -v pdftoppm >/dev/null 2>&1 && pdftoppm -png -r 300 "$1" out) || convert -density 300 -scene 1 "$1" out-%03d.png
   if [ ! -f "out-1.png" ] && [ ! -f "out-01.png" ] && [ ! -f "out-001.png" ]; then
     echo "No page images found: make sure pdftoppm (from poppler-utils) or imagemagick and ghostscript are installed"
     exit 1
@@ -10,8 +10,8 @@ pdf2images() {
 }
 
 images2write() {
-  printf '<svg id="write-document" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">\n' > $1
-  printf '<rect id="write-doc-background" width="100%%" height="100%%" fill="#808080"/>\n' >> $1
+  printf '<svg id="write-document" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">\n' > "$1"
+  printf '<rect id="write-doc-background" width="100%%" height="100%%" fill="#808080"/>\n' >> "$1"
 
   local pngpage
   for pngpage in out-*.png
@@ -23,20 +23,19 @@ images2write() {
     local width=$((width2/2))
     local height=$((height2/2))
 
-    printf '<svg class="write-page" color-interpolation="linearRGB" x="10" y="10" width="%dpx" height="%dpx" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">\n' $width $height >> $1
-    printf '  <g class="write-content write-v3" xruling="0" yruling="40" marginLeft="100" papercolor="#FFFFFF" rulecolor="#9F0000FF">\n' >> $1
-    printf '    <g class="ruleline write-no-dup" shape-rendering="crispEdges">\n' >> $1
-    printf '      <rect class="pagerect" fill="#FFFFFF" stroke="none" x="0" y="0" width="%d" height="%d" />\n' $width $height >> $1
-
-    printf '      <image x="0" y="0" width="%d" height="%d" xlink:href="data:image/png;base64,' $width $height >> $1
+    printf '<svg class="write-page" color-interpolation="linearRGB" x="10" y="10" width="%dpx" height="%dpx" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">\n' $width $height >> "$1"
+    printf '  <g class="write-content write-v3" xruling="0" yruling="40" marginLeft="100" papercolor="#FFFFFF" rulecolor="#9F0000FF">\n' >> "$1"
+    printf '    <g class="ruleline write-no-dup" shape-rendering="crispEdges">\n' >> "$1"
+    printf '      <rect class="pagerect" fill="#FFFFFF" stroke="none" x="0" y="0" width="%d" height="%d" />\n' $width $height >> "$1"
+    printf '      <image x="0" y="0" width="%d" height="%d" xlink:href="data:image/png;base64,' $width $height >> "$1"
     # doesn't seem to be a way to prevent base64 from appending newline
-    base64 $pngpage | tr -d '\n' >> $1
-    printf '"/>\n    </g>\n  </g>\n</svg>' >> $1
+    base64 $pngpage | tr -d '\n' >> "$1"
+    printf '"/>\n    </g>\n  </g>\n</svg>' >> "$1"
   done
 
-  printf "\n</svg>" >> $1
+  printf "\n</svg>" >> "$1"
 
-  gzip -S z $1
+  gzip -S z "$1"
   rm out-*.png
 }
 
@@ -57,10 +56,10 @@ do
   fi
 
   echo "Converting $PDF to images..."
-  pdf2images $PDF
+  pdf2images "$PDF"
 
   echo "Generating Write document..."
-  SVGOUT=$(basename $PDF pdf)svg
-  images2write $SVGOUT
+  SVGOUT=$(basename "$PDF" pdf)svg
+  images2write "$SVGOUT"
   echo "Finished creating ${SVGOUT}z"
 done

--- a/pdf2write.sh
+++ b/pdf2write.sh
@@ -1,6 +1,27 @@
 #!/bin/bash
 # Create a Write document from a PDF by generating page images
 
+verifyPdf() {
+  if [ -z "$1" ] # verify argument isn't empty
+  then
+    return 1
+  fi
+
+  if ! [[ $1 =~ \.pdf$ ]]; # verify argument is a pdf
+  then
+    echo "Ignoring $1 as it is not a PDF file"
+    return 1
+  fi
+
+  if [ ! -f "$1" ]; # verify argument exists
+  then
+    echo "Ignoring $1 as it does not exist"
+    return 1
+  fi
+
+  return 0
+}
+
 pdf2images() {
   (command -v pdftoppm >/dev/null 2>&1 && pdftoppm -png -r 300 "$1" out) || convert -density 300 -scene 1 "$1" out-%03d.png
   if [ ! -f "out-1.png" ] && [ ! -f "out-01.png" ] && [ ! -f "out-001.png" ]; then
@@ -70,18 +91,10 @@ do
       #;;
     *)    # unknown option
       shift # past argument
-      if [ -z "$key" ] # verify argument isn't empty
+      if verifyPdf "$key"
       then
-        continue
+        PDFSIN+=("$key")
       fi
-
-      if ! [[ $key =~ \.pdf$ ]]; # verify argument is a pdf
-      then
-        echo "Ignoring $key as it is not a PDF file"
-        continue
-      fi
-
-      PDFSIN+=("$key")
       ;;
   esac
 done

--- a/pdf2write.sh
+++ b/pdf2write.sh
@@ -55,6 +55,12 @@ do
     continue
   fi
 
+  if ! [[ $PDF =~ \.pdf$ ]];
+  then
+    echo "Skipping $PDF as it is not a PDF file"
+    continue
+  fi
+
   echo "Converting $PDF to images..."
   pdf2images "$PDF"
 

--- a/pdf2write.sh
+++ b/pdf2write.sh
@@ -48,10 +48,19 @@ if [ $# -eq 0 ]; then
   exit 0
 fi
 
-echo "Converting PDF to images..."
-pdf2images $1
+for PDF in "$@"
+do
+  # verify argument isn't empty
+  if [ -z "$PDF" ]
+  then
+    continue
+  fi
 
-echo "Generating Write document..."
-SVGOUT=$(basename $1 pdf)svg
-images2write $SVGOUT
-echo "Finished creating ${SVGOUT}z"
+  echo "Converting $PDF to images..."
+  pdf2images $PDF
+
+  echo "Generating Write document..."
+  SVGOUT=$(basename $PDF pdf)svg
+  images2write $SVGOUT
+  echo "Finished creating ${SVGOUT}z"
+done

--- a/pdf2write.sh
+++ b/pdf2write.sh
@@ -60,7 +60,7 @@ images2write() {
   done
 
   printf "\n</svg>" >> "$1"
-  [ "$COMPRESS" = true ] && gzip -S z "$SVGOUT"
+  [ "$COMPRESS" = true ] && gzip -S z "$SVGOUT" && SVGOUT="$SVGOUT"z
   rm out-*.png
 }
 
@@ -116,5 +116,5 @@ do
   echo "Generating Write document..."
   SVGOUT=$(basename "$PDF" pdf)svg
   images2write "$SVGOUT"
-  echo "Finished creating ${SVGOUT}z"
+  echo "Finished creating ${SVGOUT}"
 done

--- a/pdf2write.sh
+++ b/pdf2write.sh
@@ -2,8 +2,8 @@
 # Create a Write document from a PDF by generating page images
 
 if [ $# -eq 0 ]; then
-    echo "No arguments provided. Please specify a PDF to convert with 'pdf2write.sh /path/to/foo.pdf'"
-    exit 0
+  echo "No arguments provided. Please specify a PDF to convert with 'pdf2write.sh /path/to/foo.pdf'"
+  exit 0
 fi
 
 echo "Converting PDF to images..."


### PR DESCRIPTION
- Adds usage hint when no arguments are provided
- Adds support for multiple arguments (`pdf2write.sh pdf1.pdf pdf2.pdf`)
- Adds support for arguments with spaces (`pdf2write.sh 'My PDF.pdf'` and `pdf2write.sh My\ PDF.pdf`)
- Guards against empty arguments (`pdf2write.sh ""`)
- Guards against non-pdf arguments (`pdf2write.sh pdf1.svgz`)
- Refactors as necessary for the above additions